### PR TITLE
Update BUNDLE_VERSION to 1.16.1

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.7.12"
+  BUNDLER_VERSION      = "1.16.1"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"


### PR DESCRIPTION
This is a test to see if our failing deployments of the Rails 5 codebase has to do with a 3 year old version of Bundler. It's hard coded, which means I had to fork the repo.